### PR TITLE
add scape para '&' quando sozinho durante o parse

### DIFF
--- a/lib/OfxParser/Parser.php
+++ b/lib/OfxParser/Parser.php
@@ -83,6 +83,16 @@ class Parser
         libxml_clear_errors();
         libxml_use_internal_errors(true);
         $xml = simplexml_load_string($xmlString);
+        $xmlString = preg_replace_callback(
+            '/>([^<]&[^<])</',
+            function ($matches) {
+                $content = $matches[1];
+                // Escapa apenas o necessário e envolve em CDATA
+                return '><![CDATA[' . $content . ']]><';
+            },
+            $xmlString
+        );
+        $xml = simplexml_load_string($xmlString);
 
         if ($errors = libxml_get_errors()) {
             throw new \RuntimeException('Failed to parse OFX: ' . var_export($errors, true));


### PR DESCRIPTION
Adicionada uma etapa com preg_replace_callback durante o parsing de arquivos OFX para tratar corretamente ampersands não escapados. O callback detecta caracteres & isolados dentro de nós de texto e envolve o conteúdo em CDATA, evitando erros de parsing no simplexml_load_string e preservando os dados originais.